### PR TITLE
Add extra SSH arguments to the rsync command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ cap db:pull
 cap production db:pull # if you are using capistrano-ext to have multistages
 ```
 
+# Custom SSH config and extra arguments for the rsync command.
+
+It is possible to pass two extra arguments(capistrano server properties) to the server.
+
+* `config_file` - Use a custom ssh config file.
+* `extra_args` - Pass custom/extra SSH arguments for the rsync command.
+
+```ruby
+server 'my.server.host', user: fetch(:user), roles: %w(app web db), config_file: '.ssh/config',  extra_args: '-A'
+```
+
 ## Contributors
 
 * tilsammans (http://github.com/tilsammansee)

--- a/lib/capistrano-db-tasks/asset.rb
+++ b/lib/capistrano-db-tasks/asset.rb
@@ -9,8 +9,12 @@ module Asset
     dirs = [cap.fetch(:assets_dir)].flatten
     local_dirs = [cap.fetch(:local_assets_dir)].flatten
 
+    config_file = server.properties.config_file || nil
+    extra_args = server.properties.extra_args || ''
+    extra_args += " -F #{config_file}" if config_file
+
     dirs.each_index do |idx|
-      system("rsync -a --del -L -K -vv --progress --rsh='ssh -p #{port}' #{user}@#{server}:#{cap.current_path}/#{dirs[idx]} #{local_dirs[idx]}")
+      system("rsync -a --del -L -K -vv --progress --rsh='ssh -p #{port} #{extra_args}' #{user}@#{server}:#{cap.current_path}/#{dirs[idx]} #{local_dirs[idx]}")
     end
   end
 
@@ -22,8 +26,12 @@ module Asset
     dirs = [cap.fetch(:assets_dir)].flatten
     local_dirs = [cap.fetch(:local_assets_dir)].flatten
 
+    config_file = server.properties.config_file || nil
+    extra_args = server.properties.extra_args || ''
+    extra_args += " -F #{config_file}" if config_file
+
     dirs.each_index do |idx|
-      system("rsync -a --del -L -K -vv --progress --rsh='ssh -p #{port}' ./#{dirs[idx]} #{user}@#{server}:#{cap.current_path}/#{local_dirs[idx]}")
+      system("rsync -a --del -L -K -vv --progress --rsh='ssh -p #{port} #{extra_args}' ./#{dirs[idx]} #{user}@#{server}:#{cap.current_path}/#{local_dirs[idx]}")
     end
   end
 


### PR DESCRIPTION
Some times it is needed to pass extra SSH arguments like forward agent or use a custom config file.

_**Unfortunately, no time to start working in a test suite, right now**_